### PR TITLE
Card size in different modules

### DIFF
--- a/app/src/main/java/com/piapps/flashcardpro/features/editor/SetFragment.kt
+++ b/app/src/main/java/com/piapps/flashcardpro/features/editor/SetFragment.kt
@@ -92,7 +92,7 @@ class SetFragment : BaseFragment(), SetEditorView,
     lateinit var ivSetColor: AppCompatImageView
     lateinit var rv: RecyclerView
     lateinit var rvLabels: RecyclerView
-    lateinit var fab: FloatingActionButton
+    lateinit var ivAdd: AppCompatImageView
     lateinit var ivBottomMenu: AppCompatImageView
     lateinit var ivStudy: AppCompatImageView
     lateinit var ivQuiz: AppCompatImageView
@@ -121,7 +121,7 @@ class SetFragment : BaseFragment(), SetEditorView,
             showSetTitleEditor(presenter.set.title)
         }
 
-        fab.setOnClickListener {
+        ivAdd.setOnClickListener {
             presenter.addNewCard()
         }
 

--- a/app/src/main/java/com/piapps/flashcardpro/features/editor/SetUI.kt
+++ b/app/src/main/java/com/piapps/flashcardpro/features/editor/SetUI.kt
@@ -63,7 +63,6 @@ fun SetFragment.UI(): View {
             }
             itemAnimator = LandingAnimator()
             clipToPadding = false
-            padding = dip(32)
             this@UI.layoutManager = LinearLayoutManager(ctx, LinearLayoutManager.HORIZONTAL, false)
             layoutManager = this@UI.layoutManager
             adapter = this@UI.adapter
@@ -118,6 +117,14 @@ fun SetFragment.UI(): View {
                 setIconColor(ctx, theme.colorIconActive)
                 setRippleEffect()
             }
+            
+            ivAdd = imageView {
+                layoutParams = FrameLayout.LayoutParams(dip(56), dip(56))
+                padding = dip(14)
+                setImageResource(R.drawable.ic_add)
+                setIconColor(ctx, theme.colorIconActive)
+                setRippleEffect()
+            }
         }
 
         view {
@@ -126,18 +133,6 @@ fun SetFragment.UI(): View {
                 gravity = Gravity.BOTTOM
             }
             setBackgroundResource(R.drawable.pre_lollipop_elevation_up)
-        }
-
-        fab = floatingActionButton {
-            layoutParams = FrameLayout.LayoutParams(dip(56), dip(56)).apply {
-                gravity = Gravity.BOTTOM or Gravity.END
-                bottomMargin = dip(28)
-                rightMargin = dip(16)
-            }
-            backgroundTintList = ColorStateList.valueOf(ContextCompat.getColor(ctx, theme.colorAccent))
-            rippleColor = ContextCompat.getColor(ctx, theme.colorDivider)
-            setImageResource(R.drawable.ic_add)
-            setIconColor(ctx, theme.white)
         }
 
         view {

--- a/app/src/main/java/com/piapps/flashcardpro/features/editor/adapter/cells/CardUI.kt
+++ b/app/src/main/java/com/piapps/flashcardpro/features/editor/adapter/cells/CardUI.kt
@@ -43,8 +43,8 @@ class CardUI {
                 layoutParams = FrameLayout.LayoutParams(matchParent, matchParent).apply {
                     topMargin = dip(32)
                     bottomMargin = dip(32)
-                    leftMargin = dip(16)
-                    rightMargin = dip(16)
+                    leftMargin = dip(8)
+                    rightMargin = dip(8)
                 }
 
                 // front

--- a/app/src/main/java/com/piapps/flashcardpro/features/quiz/adapter/CardUI.kt
+++ b/app/src/main/java/com/piapps/flashcardpro/features/quiz/adapter/CardUI.kt
@@ -35,10 +35,10 @@ class CardUI {
             cardView {
                 id = rootId
                 layoutParams = FrameLayout.LayoutParams(matchParent, matchParent).apply {
-                    topMargin = dip(54)
-                    bottomMargin = dip(54)
-                    leftMargin = dip(38)
-                    rightMargin = dip(38)
+                    topMargin = dip(32)
+                    bottomMargin = dip(32)
+                    leftMargin = dip(8)
+                    rightMargin = dip(8)
                 }
 
                 // front

--- a/app/src/main/java/com/piapps/flashcardpro/features/study/StudyFragment.kt
+++ b/app/src/main/java/com/piapps/flashcardpro/features/study/StudyFragment.kt
@@ -55,7 +55,6 @@ class StudyFragment : BaseFragment(), StudyView {
 
     override fun viewCreated(view: View?, args: Bundle?) {
         super.viewCreated(view, args)
-        activity?.window?.decorView?.systemUiVisibility = View.SYSTEM_UI_FLAG_FULLSCREEN
         presenter = StudyPresenter(this)
         appComponent.inject(presenter)
 

--- a/app/src/main/java/com/piapps/flashcardpro/features/study/adapter/CardUI.kt
+++ b/app/src/main/java/com/piapps/flashcardpro/features/study/adapter/CardUI.kt
@@ -35,10 +35,10 @@ class CardUI {
             cardView {
                 id = rootId
                 layoutParams = FrameLayout.LayoutParams(matchParent, matchParent).apply {
-                    topMargin = dip(54)
-                    bottomMargin = dip(54)
-                    leftMargin = dip(38)
-                    rightMargin = dip(38)
+                    topMargin = dip(32)
+                    bottomMargin = dip(32)
+                    leftMargin = dip(8)
+                    rightMargin = dip(8)
                 }
 
                 // front


### PR DESCRIPTION
I was able to solve issue #17 with cards being different sizes in each mode by making changes to the margins and paddings. I also disabled fullscreen mode in study mode. The cards are now proportional when switching between modes. The floating action button in editor mode was conflicting with the card so I thought that it would be better to move it to the bottom menu. I hope you like the changes and merge my pull request.