### PR TITLE
Update strings.xml: Changed "Reverse cards" to "Flip cards" in hamburger menu.

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,7 +33,7 @@
     <string name="trash_cleared">Trash is empty</string>
 
     <string name="statistics">Statistics</string>
-    <string name="reverse_cards">Reverse cards</string>
+    <string name="reverse_cards">Flip cards</string>
     <string name="shuffle_cards">Shuffle cards</string>
     <string name="sort_cards_alph">Sort cards alphabetically</string>
     <string name="export_to_csv">Export to CSV</string>


### PR DESCRIPTION
Changed "Reverse cards" to "Flip cards" in hamburger menu.

I'm a native English speaker and I think that it is better to say "flip cards" instead of "reverse cards". "Reverse cards" can be thought of as reversing each card's position from 1, 2, 3 to 3, 2, 1, while flip means to turn over something quickly which is exactly what is happening here.

Thank you for considering my pull request.